### PR TITLE
feat: ignoreRestSibilings in `@typescript-eslint/no-unused-vars`

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = {
             }
         ],
         "@typescript-eslint/no-unused-vars": ["error", {
-            "varsIgnorePattern": "^_"
+            "varsIgnorePattern": "^_",
+            "ignoreRestSiblings": true
         }],
         "@typescript-eslint/explicit-function-return-type": ["error", {
             "allowExpressions": true


### PR DESCRIPTION
implement [`ignoreRestSiblings`](https://eslint.org/docs/latest/rules/no-unused-vars#varsignorepattern) to `true` for [`@typescript-eslint/no-unused-vars`
](https://eslint.org/docs/latest/rules/no-unused-vars#varsignorepattern)

This is pretty useful in cases when you want to filter out some values of an object.

Let's take an array of objects of this type
```ts
interface SomeData {
  id: string;
  name: string;
  salary: number;
}
```

as a result, we want to get an array without the `id` field, and to achieve this we need to specify every field
```js
const noIdData = somedata.map((data) => {
  name: data.name,
  salary: data.salary,
})
```

and with enabled [`ignoreRestSiblings`](https://eslint.org/docs/latest/rules/no-unused-vars#varsignorepattern) we can use destruction to achieve the same goal in cleaner matter
```js
const noIdData = somedata.map(({id, ...data}) => data)
```